### PR TITLE
Add the twig extension support

### DIFF
--- a/twigextensions/CollectionsTwigExtension.php
+++ b/twigextensions/CollectionsTwigExtension.php
@@ -25,7 +25,7 @@ class CollectionsTwigExtension extends \Twig_Extension
     public function getFilters()
     {
         return [
-            'collecy' => new \Twig_Filter_Method(
+            'collect' => new \Twig_Filter_Method(
                 $this, 'collect'
             ),
         ];

--- a/twigextensions/CollectionsTwigExtension.php
+++ b/twigextensions/CollectionsTwigExtension.php
@@ -1,0 +1,58 @@
+<?php
+namespace Craft;
+
+use Twig_Extension;
+use Twig_Filter_Method;
+use Twig_Function_Method;
+
+class CollectionsTwigExtension extends \Twig_Extension
+{
+    /**
+    * Returns the extension name.
+    *
+    * @return string
+    */
+    public function getName()
+    {
+        return "Collections";
+    }
+
+    /**
+    * Returns the extensions filters.
+    *
+    * @return array
+    */
+    public function getFilters()
+    {
+        return [
+            'collecy' => new \Twig_Filter_Method(
+                $this, 'collect'
+            ),
+        ];
+    }
+
+    /**
+    * Returns the extensions functions.
+    *
+    * @return string
+    */
+    public function getFunctions()
+    {
+        return [
+            'collect' => new \Twig_Function_Method(
+                $this, 'collect'
+            ),
+        ];
+    }
+
+    /**
+    * Returns the array as a collection.
+    *
+    * @param array
+    * @return Collection
+    */
+    public function collect($array)
+    {
+        return craft()->collections->make($array);
+    }
+}


### PR DESCRIPTION
Adds twig extension support to plugin.

Allows the following:

```
{{ collect({ 'foo': 'foo', 'bar': 'bar' }) }}
```

and

```
{{ { 'foo': 'foo', 'bar': 'bar' } | collect }}
```
